### PR TITLE
some edits so site performs on IE11/other older browsers

### DIFF
--- a/src/components/buttons/generic/FaceButton.vue
+++ b/src/components/buttons/generic/FaceButton.vue
@@ -12,11 +12,11 @@
 <style module>
   .container {
     cursor: pointer;
-    height: 30vmax;
+    height: calc(20vh + 20vw);
     margin: 5vmin;
     max-height: 100vmin;
     max-width: 100vmin;
-    width: 30vmax;
+    width: calc(20vh + 20vw);
   }
 
   .container:hover, .container:focus path {

--- a/src/components/buttons/generic/GenericButton.vue
+++ b/src/components/buttons/generic/GenericButton.vue
@@ -12,8 +12,8 @@
 
 <style module>
   .container {
-    border: 2px solid #000;
-    color: #000;
+    border: 2px solid #fff;
+    color: #fff;
     cursor: pointer;
     display: inline-block;
     font-size: 4vmin;
@@ -22,11 +22,13 @@
   }
 
   .container:hover, .container:focus {
-    border-color: #fff;
+    background-color: rgba(255, 255, 255, 0.15);
     color: #fff;
   }
 
   .link {
+    background: transparent;
     border: none;
+    color: #000;
   }
 </style>

--- a/src/components/fullscreen-quote/FullScreenQuote.vue
+++ b/src/components/fullscreen-quote/FullScreenQuote.vue
@@ -41,6 +41,7 @@
 <style module>
   .container {
     text-align: center;
+    width: 100%;
   }
 
   .buttons {


### PR DESCRIPTION
- button styling made more appropriate for mobile devices (less emphasis on hover & focus states)
- vmax (used to calc FaceButton height & width) replaced with a calc that is more cross-browser friendly
- Main fullscreenQuote section gets width: 100% as a polyfill for IE11 (no visible change)